### PR TITLE
fix: maintainers email syntax needed for helm lint

### DIFF
--- a/searxng/Chart.yaml
+++ b/searxng/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://hub.docker.com/r/searxng/searxng
 maintainers:
   - name: unixfox
-    email: searxngatunixfoxdoteu
+    email: searxng@unixfoxremovemeifyouwanttocontactme.eu
 dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com


### PR DESCRIPTION
Syntax is wrong and makes `helm lint` fail.

```
    ==> Linting /tmp/helmfile3357475323/cleyrop/searxng/searxng/searxng/1.0.0/searxng
    [ERROR] Chart.yaml: invalid email 'searxngatunixfoxdoteu' for maintainer 'unixfox'
    Error: 1 chart(s) linted, 1 chart(s) failed
```